### PR TITLE
Add LLM-friendly content formats and improve SEO metadata

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,12 @@ metaDataFormat = "yaml"
     baseName = "llms"
     isPlainText = true
     notAlternative = true
+  [outputFormats.llmsfulltxt]
+    name = "llmsfulltxt"
+    mediaType = "text/plain"
+    baseName = "llms-full"
+    isPlainText = true
+    notAlternative = true
 
 [outputs]
-  home = ["HTML", "RSS", "llmstxt"]
+  home = ["HTML", "RSS", "llmstxt", "llmsfulltxt"]

--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,17 @@ metaDataFormat = "yaml"
     baseName = "llms-full"
     isPlainText = true
     notAlternative = true
+  [outputFormats.markdown]
+    name = "markdown"
+    mediaType = "text/markdown"
+    baseName = "index"
+    isPlainText = true
+    notAlternative = true
+
+[mediaTypes]
+  [mediaTypes."text/markdown"]
+    suffixes = ["md"]
 
 [outputs]
   home = ["HTML", "RSS", "llmstxt", "llmsfulltxt"]
+  page = ["HTML", "markdown"]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,6 @@
 {{ define "content" }}
+{{- $readingTime := math.Round (div .WordCount 200.0) }}
+{{- if lt $readingTime 1 }}{{ $readingTime = 1 }}{{ end }}
 
 <div class="container">
     <main class="article">
@@ -7,7 +9,7 @@
                 <a href="/">&larr; Go back</a>
                 <h1>{{ .Title }}</h1>
 
-                <p class="article-date">{{ .Date.Format "02 Jan 2006" }}</p>
+                <p class="article-date">{{ .Date.Format "02 Jan 2006" }} · {{ $readingTime }} min read</p>
             </header>
             <p>
                 {{ .Content }}

--- a/layouts/_default/single.markdown.txt
+++ b/layouts/_default/single.markdown.txt
@@ -1,0 +1,28 @@
+---
+title: "{{ .Title }}"
+date: {{ .PublishDate.Format "2006-01-02" }}
+author: {{ .Site.Params.author }}
+url: {{ .Permalink }}
+{{- with .Description }}
+description: "{{ . }}"
+{{- end }}
+{{- with .Params.tags }}
+tags: [{{ delimit . ", " }}]
+{{- end }}
+{{- with .Params.event }}
+event: "{{ . }}"
+{{- end }}
+{{- with .Params.event_url }}
+event_url: {{ . }}
+{{- end }}
+{{- with .Params.slides }}
+slides: {{ . }}
+{{- end }}
+{{- with .Params.video }}
+video: {{ . }}
+{{- end }}
+---
+
+# {{ .Title }}
+
+{{ .RawContent }}

--- a/layouts/index.llmsfulltxt.txt
+++ b/layouts/index.llmsfulltxt.txt
@@ -1,0 +1,64 @@
+# {{ .Site.Params.author }}'s Blog - Full Content
+
+> {{ .Site.Params.description }}
+
+This file contains the complete content of all blog posts for LLMs and AI assistants.
+
+---
+
+## About the Author
+
+**{{ .Site.Params.author }}**
+
+{{ .Site.Params.description }}
+
+- Website: {{ .Site.BaseURL }}
+- GitHub: https://github.com/{{ .Site.Params.github }}
+
+---
+
+## Blog Posts
+{{ range where (.Site.RegularPages.ByDate.Reverse) "Section" "post" }}
+### {{ .Title }}
+
+- **URL**: {{ .Permalink }}
+- **Published**: {{ .PublishDate.Format "January 2, 2006" }}
+- **Word Count**: {{ .WordCount }} words
+{{- with .Params.tags }}
+- **Tags**: {{ delimit . ", " }}
+{{- end }}
+{{- with .Description }}
+- **Summary**: {{ . }}
+{{- end }}
+
+{{ .RawContent }}
+
+---
+{{ end }}
+
+## Talks & Presentations
+{{ range where (.Site.RegularPages.ByDate.Reverse) "Section" "talk" }}
+### {{ .Title }}
+
+- **URL**: {{ .Permalink }}
+- **Date**: {{ .PublishDate.Format "January 2, 2006" }}
+{{- with .Params.event }}
+- **Event**: {{ . }}
+{{- end }}
+{{- with .Params.event_url }}
+- **Event URL**: {{ . }}
+{{- end }}
+{{- with .Params.slides }}
+- **Slides**: {{ . }}
+{{- end }}
+{{- with .Params.video }}
+- **Video**: {{ . }}
+{{- end }}
+{{- with .Description }}
+- **Summary**: {{ . }}
+{{- end }}
+
+{{ .RawContent }}
+
+---
+{{ end }}

--- a/layouts/index.llmstxt.txt
+++ b/layouts/index.llmstxt.txt
@@ -11,13 +11,17 @@ This file provides an overview of the blog content for LLMs and AI assistants.
 - GitHub: https://github.com/{{ .Site.Params.github }}
 
 ## Blog Posts
+
+Each post is available as markdown at `{url}index.md` for LLM consumption.
 {{ range where (.Site.RegularPages.ByDate.Reverse) "Section" "post" }}
-- [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+- [{{ .Title }}]({{ .Permalink }}) ([md]({{ .Permalink }}index.md)){{ with .Description }}: {{ . }}{{ end }}
 {{- end }}
 
 ## Talks & Presentations
+
+Each talk is available as markdown at `{url}index.md` for LLM consumption.
 {{ range where (.Site.RegularPages.ByDate.Reverse) "Section" "talk" }}
-- [{{ .Title }}]({{ .Permalink }}){{ with .Params.event }} ({{ . }}){{ end }}{{ with .Description }}: {{ . }}{{ end }}
+- [{{ .Title }}]({{ .Permalink }}) ([md]({{ .Permalink }}index.md)){{ with .Params.event }} ({{ . }}){{ end }}{{ with .Description }}: {{ . }}{{ end }}
 {{- end }}
 
 ## Resources

--- a/layouts/index.llmstxt.txt
+++ b/layouts/index.llmstxt.txt
@@ -2,7 +2,26 @@
 
 > {{ .Site.Params.description }}
 
-## Posts
+This file provides an overview of the blog content for LLMs and AI assistants.
+
+## About
+
+- Author: {{ .Site.Params.author }}
+- Website: {{ .Site.BaseURL }}
+- GitHub: https://github.com/{{ .Site.Params.github }}
+
+## Blog Posts
 {{ range where (.Site.RegularPages.ByDate.Reverse) "Section" "post" }}
 - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
 {{- end }}
+
+## Talks & Presentations
+{{ range where (.Site.RegularPages.ByDate.Reverse) "Section" "talk" }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Params.event }} ({{ . }}){{ end }}{{ with .Description }}: {{ . }}{{ end }}
+{{- end }}
+
+## Resources
+
+- [Full Content for LLMs]({{ .Site.BaseURL }}llms-full.txt): Complete article content for deeper context
+- [RSS Feed]({{ .Site.BaseURL }}index.xml): Subscribe to updates
+- [Sitemap]({{ .Site.BaseURL }}sitemap.xml): All pages on this site

--- a/layouts/partials/seo_schema.html
+++ b/layouts/partials/seo_schema.html
@@ -53,6 +53,8 @@
 {{- end }}
 
 {{/* JSON-LD Structured Data */}}
+{{- $readingTime := math.Round (div .WordCount 200.0) }}
+{{- if lt $readingTime 1 }}{{ $readingTime = 1 }}{{ end }}
 <script type="application/ld+json">
 {
     "@context": "https://schema.org",
@@ -66,7 +68,13 @@
     "inLanguage": "en-US",
     "author": {
         "@type": "Person",
-        "name": "{{ .Site.Params.author }}"
+        "name": "{{ .Site.Params.author }}",
+        "url": "{{ .Site.BaseURL }}",
+        "sameAs": [
+            "https://github.com/{{ .Site.Params.github }}",
+            "https://linkedin.com/in/vtemian",
+            "https://x.com/vlogthedevelop"
+        ]
     },
     "publisher": {
         "@type": "Person",
@@ -76,7 +84,38 @@
     "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}",
     "url": "{{ .Permalink }}",
     "wordCount": {{ .WordCount }},
+    "timeRequired": "PT{{ $readingTime }}M",
     "keywords": [{{ range $i, $tag := .Params.tags }}{{ if $i }}, {{ end }}"{{ $tag }}"{{ end }}]
+}
+</script>
+
+{{/* Breadcrumb Schema */}}
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "{{ .Site.BaseURL }}"
+        }
+        {{- if .IsPage }},
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "{{ .Section | title }}",
+            "item": "{{ .Site.BaseURL }}{{ .Section }}/"
+        },
+        {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "{{ .Title }}",
+            "item": "{{ .Permalink }}"
+        }
+        {{- end }}
+    ]
 }
 </script>
 

--- a/layouts/partials/seo_schema.html
+++ b/layouts/partials/seo_schema.html
@@ -73,7 +73,7 @@
         "sameAs": [
             "https://github.com/{{ .Site.Params.github }}",
             "https://linkedin.com/in/vtemian",
-            "https://x.com/vlogthedevelop"
+            "https://x.com/vtemian"
         ]
     },
     "publisher": {

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,3 +1,8 @@
 User-agent: *
 
 Sitemap: {{ "sitemap.xml" | absURL }}
+
+# LLM-friendly content
+# See https://llmstxt.org for the specification
+LLMsTxt: {{ "llms.txt" | absURL }}
+LLMsFullTxt: {{ "llms-full.txt" | absURL }}


### PR DESCRIPTION
## Summary
This PR enhances the blog's accessibility for LLMs and AI assistants while improving SEO metadata. It introduces new output formats for LLM consumption, adds reading time estimates, and expands structured data markup.

## Key Changes

### LLM-Friendly Content Formats
- Added `llmsfulltxt` output format for complete blog content in a single file
- Added `markdown` output format to generate `.md` files for each page
- Updated `config.toml` to register new media types and output formats
- Updated `robots.txt` to advertise LLM content endpoints per [llmstxt.org](https://llmstxt.org) specification

### Content Generation
- Created `layouts/index.llmsfulltxt.txt` template that aggregates all blog posts and talks with full content
- Updated `layouts/index.llmstxt.txt` to provide an overview with links to markdown versions and full content file
- Created `layouts/_default/single.markdown.txt` template to generate markdown files for individual pages with YAML frontmatter

### Reading Time & UX
- Added reading time calculation (200 words/minute) to article headers
- Implemented reading time display in `layouts/_default/single.html`
- Added `timeRequired` field to JSON-LD schema for better SEO

### Enhanced SEO & Structured Data
- Expanded author information in JSON-LD with URL and social media links (GitHub, LinkedIn, X)
- Added Breadcrumb Schema for improved navigation in search results
- Improved schema completeness with keywords and reading time metadata

## Implementation Details
- Reading time calculation uses `math.Round` and defaults to 1 minute minimum
- Markdown output format uses `index` as base name to generate `index.md` files
- LLM content templates use `RawContent` to preserve markdown formatting
- Breadcrumb schema conditionally includes section and page items based on page type

https://claude.ai/code/session_014GHxMd2J12TgkVoxUoBu5S

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LLM-friendly content outputs and richer SEO metadata. Improves discoverability, provides per-article markdown, and shows reading time on posts.

- New Features
  - New output formats: llmsfulltxt (llms-full.txt) and markdown (index.md per page)
  - Enhanced llms.txt with author info, talks, and resource links (RSS, sitemap, full content)
  - New templates for full-content and per-page markdown; endpoints advertised in robots.txt
  - Reading time displayed in post headers (200 wpm, min 1 min)

- SEO & Structured Data
  - Added JSON-LD: timeRequired, keywords, wordCount
  - Enriched Person schema with site URL and social links (GitHub, LinkedIn, X)
  - Added BreadcrumbList for better navigation in search results

<sup>Written for commit 20d9209d3aa11fbc20cde5d5edec56c489cefb5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

