### PR TITLE
Add dark mode toggle

### DIFF
--- a/assets/stylesheets/main.css
+++ b/assets/stylesheets/main.css
@@ -2,6 +2,8 @@
 @source "../../layouts";
 @source "../../content";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --color-ink: #2c3b49;
   --color-muted: #60646F;
@@ -16,28 +18,40 @@
   --font-mono: "Geist Mono", ui-monospace, monospace;
 }
 
+.dark {
+  --color-ink: #EFEFEF;
+  --color-muted: #bec8de;
+  --color-border: #2e3038;
+  --color-surface: #1e2025;
+  --color-code-bg: #1e2025;
+  --color-code-border: #212224;
+  --color-bg: #151618;
+  --color-link: #7a8a9a;
+  --color-link-border: #212224;
+}
+
 pre code.hljs {
-  @apply rounded-none;
+  @apply rounded-none text-xs;
 }
 
 article div h1 {
-  @apply text-xl font-normal mt-6;
+  @apply mt-6 text-xl font-normal;
 }
 
 article div h2 {
-  @apply text-lg font-normal mt-6;
+  @apply mt-6 text-lg font-normal;
 }
 
 article div h3 {
-  @apply text-base font-normal mt-6;
+  @apply mt-6 text-base font-normal;
 }
 
 article div h4 {
-  @apply text-sm font-normal mt-6;
+  @apply mt-6 text-sm font-normal;
 }
 
 article div a {
-  @apply text-link border-b border-b-link-border hover:text-ink hover:border-b-ink transition-all duration-200 ease-out pb-0.5;
+  @apply border-b border-b-link-border pb-0.5 text-link transition-all duration-200 ease-out hover:border-b-ink hover:text-ink;
 }
 
 article div hr {
@@ -49,7 +63,7 @@ article div strong {
 }
 
 article div table {
-  @apply w-full border-separate border-spacing-0 overflow-hidden rounded-lg border border-link-border;
+  @apply w-full overflow-hidden border-separate border-spacing-0 rounded-lg border border-link-border;
 }
 
 article div th:not(:last-child),
@@ -72,7 +86,7 @@ article div td {
 }
 
 article div th {
-  @apply text-xs text-muted font-normal;
+  @apply font-normal text-xs text-muted;
 }
 
 article div tr {
@@ -84,13 +98,29 @@ article div tbody tr:hover {
 }
 
 article div ul {
-  @apply list-disc pl-5 flex flex-col gap-2;
+  @apply flex list-disc flex-col gap-2 pl-5;
 }
 
 article div ol {
-  @apply list-decimal pl-5 flex flex-col gap-2;
+  @apply flex list-decimal flex-col gap-2 pl-5;
+}
+
+article div sup {
+  @apply font-mono text-xs text-muted;
+}
+
+article div .mermaid {
+  @apply flex justify-center;
+}
+
+.references {
+  @apply flex flex-col gap-2 text-xs;
+}
+
+.references .ref-num {
+  @apply font-mono text-muted;
 }
 
 article div :not(pre) > code {
-  @apply whitespace-normal bg-code-bg border border-code-border break-words rounded px-0.5;
+  @apply break-words whitespace-normal rounded border border-code-border bg-code-bg px-0.5;
 }

--- a/content/post/mcp-is-great-for-tools-terrible-for-agents/index.md
+++ b/content/post/mcp-is-great-for-tools-terrible-for-agents/index.md
@@ -228,18 +228,22 @@ Stay curious ☕
 
 ---
 
-**References**
+### References
 
-<a id="ref-1"></a>[1] JSON-RPC 2.0 Specification -[jsonrpc.org/specification](https://www.jsonrpc.org/specification)
+<div class="references">
 
-<a id="ref-2"></a>[2] MCP Specification: Transports -[modelcontextprotocol.io/specification/2025-11-25/basic/transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
+<p id="ref-1"><span class="ref-num">[1]</span> JSON-RPC 2.0 Specification - <a href="https://www.jsonrpc.org/specification">jsonrpc.org/specification</a></p>
 
-<a id="ref-3"></a>[3] MCP Specification: Lifecycle -[modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+<p id="ref-2"><span class="ref-num">[2]</span> MCP Specification: Transports - <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports">modelcontextprotocol.io/specification/2025-11-25/basic/transports</a></p>
 
-<a id="ref-4"></a>[4] MCP Specification: Tools -[modelcontextprotocol.io/specification/2025-11-25/server/tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+<p id="ref-3"><span class="ref-num">[3]</span> MCP Specification: Lifecycle - <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle">modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle</a></p>
 
-<a id="ref-5"></a>[5] Claudebin source code -[github.com/wunderlabs-dev/claudebin](https://github.com/wunderlabs-dev/claudebin)
+<p id="ref-4"><span class="ref-num">[4]</span> MCP Specification: Tools - <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools">modelcontextprotocol.io/specification/2025-11-25/server/tools</a></p>
 
-<a id="ref-6"></a>[6] JavaScript's internal character encoding: UCS-2 or UTF-16? -[mathiasbynens.be/notes/javascript-encoding](https://mathiasbynens.be/notes/javascript-encoding)
+<p id="ref-5"><span class="ref-num">[5]</span> Claudebin source code - <a href="https://github.com/wunderlabs-dev/claudebin">github.com/wunderlabs-dev/claudebin</a></p>
 
-<a id="ref-7"></a>[7] RFC 8628: OAuth 2.0 Device Authorization Grant -[datatracker.ietf.org/doc/html/rfc8628](https://datatracker.ietf.org/doc/html/rfc8628)
+<p id="ref-6"><span class="ref-num">[6]</span> JavaScript's internal character encoding: UCS-2 or UTF-16? - <a href="https://mathiasbynens.be/notes/javascript-encoding">mathiasbynens.be/notes/javascript-encoding</a></p>
+
+<p id="ref-7"><span class="ref-num">[7]</span> RFC 8628: OAuth 2.0 Device Authorization Grant - <a href="https://datatracker.ietf.org/doc/html/rfc8628">datatracker.ietf.org/doc/html/rfc8628</a></p>
+
+</div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <script>if(localStorage.getItem('theme')==='dark')document.documentElement.classList.add('dark')</script>
         {{ partial "header" .}}
         <meta name="google-site-verification" content="2qk_e0y84NNSVpaorKgeNURYF9Ni3UyJvPq9GZdGEgs" />
     </head>
 
-    <body class="bg-bg text-ink font-sans text-sm leading-relaxed antialiased ">
+    <body class="bg-bg font-sans text-sm leading-relaxed text-ink antialiased">
         {{ block "content" .}}{{ end }}
     </body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ define "content" }}
 
-<div class="max-w-xl mx-auto py-12 px-5 flex flex-col gap-12">
+<div class="mx-auto flex max-w-xl flex-col gap-12 px-5 py-12">
 
     <svg width="0" height="0" class="absolute">
         <defs>
@@ -11,39 +11,39 @@
     </svg>
 
     <section class="flex items-center gap-4">
-        <img src="https://qed.builders/images/team/vlad-temian@2x.png" alt="Vlad Temian" class="w-14 h-14" style="clip-path: url(#squircle)">
-        <div>
+        <img src="https://qed.builders/images/team/vlad-temian@2x.png" alt="Vlad Temian" class="h-14 w-14" style="clip-path: url(#squircle)">
+        <div class="flex-1">
             <p>Vlad Temian</p>
             <p>Centrist Tech Optimist</p>
         </div>
+        {{ partial "theme-toggle" . }}
     </section>
 
     <section>
-        <h2 class="font-mono text-xs text-muted tracking-wide mb-4">About</h2>
+        <h2 class="mb-4 font-mono text-xs tracking-wide text-muted">About</h2>
         <p>I build agentic programming tools.</p>
         <br>
-        <p>15+ years helping startups scale production infrastructure.
-        <br>Former CTO of <a href="https://www.linkedin.com/company/qed-builders-software/" target="_blank" rel="noopener noreferrer" class="text-link border-b border-b-link-border hover:text-ink hover:border-b-ink transition-all duration-200 ease-out pb-0.5">qed.builders</a> (acquired by <a href="https://www.linkedin.com/company/thesandbox-game/" target="_blank" rel="noopener noreferrer" class="text-link border-b border-b-link-border hover:text-ink hover:border-b-ink transition-all duration-200 ease-out pb-0.5">The Sandbox</a>).
-        <br>Organizer at <a href="https://agentic.tm" target="_blank" rel="noopener noreferrer" class="text-link border-b border-b-link-border hover:text-ink hover:border-b-ink transition-all duration-200 ease-out pb-0.5">agentic.tm</a>. <a href="https://cursor.com" target="_blank" rel="noopener noreferrer" class="text-link border-b border-b-link-border hover:text-ink hover:border-b-ink transition-all duration-200 ease-out pb-0.5">Cursor</a> ambassador.</p>
+        <p>15+ years helping startups scale production infrastructure.</p>
+        <p>Former CTO of <a href="https://www.linkedin.com/company/qed-builders-software/" target="_blank" rel="noopener noreferrer" class="border-b border-b-link-border pb-0.5 text-link transition-all duration-200 ease-out hover:border-b-ink hover:text-ink">qed.builders</a> (acquired by <a href="https://www.linkedin.com/company/thesandbox-game/" target="_blank" rel="noopener noreferrer" class="border-b border-b-link-border pb-0.5 text-link transition-all duration-200 ease-out hover:border-b-ink hover:text-ink">The Sandbox</a>). Organizer at <a href="https://agentic.tm" target="_blank" rel="noopener noreferrer" class="border-b border-b-link-border pb-0.5 text-link transition-all duration-200 ease-out hover:border-b-ink hover:text-ink">agentic.tm</a>. <a href="https://cursor.com" target="_blank" rel="noopener noreferrer" class="border-b border-b-link-border pb-0.5 text-link transition-all duration-200 ease-out hover:border-b-ink hover:text-ink">Cursor</a> ambassador.</p>
         <br>
         <p>I believe everyone should be able to ship ideas.</p>
     </section>
 
     <section>
-        <h2 class="font-mono text-xs text-muted tracking-wide mb-4">Writing</h2>
+        <h2 class="mb-4 font-mono text-xs tracking-wide text-muted">Writing</h2>
         {{ $posts := where .Site.RegularPages "Section" "post" }}
         {{ $talks := where .Site.RegularPages "Section" "talk" }}
         {{ $projects := where .Site.RegularPages "Section" "project" }}
         {{ $all := $posts | union $talks | union $projects }}
         <div class="relative flex flex-col gap-1" id="writing-list">
-        <div id="writing-highlight" class="absolute bg-surface rounded-lg pointer-events-none opacity-0 transition-all duration-150"></div>
+        <div id="writing-highlight" class="pointer-events-none absolute rounded-lg bg-surface opacity-0 transition-all duration-150"></div>
         {{ range $all.ByDate.Reverse }}
-        <a href="{{ .RelPermalink }}" class="flex justify-between items-center gap-4 -mx-3 px-3 py-2 rounded-lg relative">
+        <a href="{{ .RelPermalink }}" class="relative -mx-3 flex items-center justify-between gap-4 rounded-lg px-3 py-2 transition-colors duration-150">
             <div class="min-w-0">
                 <h3 class="truncate">{{ .Title }}</h3>
-                <p class="text-link text-xs">{{ .Date.Format "January 2006" }}</p>
+                <p class="text-xs text-link">{{ .Date.Format "January 2006" }}</p>
             </div>
-            <span class="text-xs text-muted border border-border rounded px-2 py-0.5 shrink-0 capitalize">{{ .Section }}</span>
+            <span class="shrink-0 rounded border border-border px-2 py-0.5 text-xs capitalize text-muted">{{ .Section }}</span>
         </a>
         {{ end }}
         </div>
@@ -82,22 +82,22 @@
     </section>
 
     <section>
-        <h2 class="font-mono text-xs text-muted tracking-wide mb-4">Contact</h2>
+        <h2 class="mb-4 font-mono text-xs tracking-wide text-muted">Contact</h2>
         <div class="flex flex-col gap-2">
             <div class="grid grid-cols-12 gap-2">
-                <span class="text-muted col-span-4">Email</span>
+                <span class="col-span-4 text-muted">Email</span>
                 <a href="mailto:me@vtemian.com" class="col-span-8">me@vtemian.com</a>
             </div>
             <div class="grid grid-cols-12 gap-2">
-                <span class="text-muted col-span-4">LinkedIn</span>
+                <span class="col-span-4 text-muted">LinkedIn</span>
                 <a href="https://www.linkedin.com/in/vtemian" class="col-span-8">/in/vtemian</a>
             </div>
             <div class="grid grid-cols-12 gap-2">
-                <span class="text-muted col-span-4">GitHub</span>
+                <span class="col-span-4 text-muted">GitHub</span>
                 <a href="https://github.com/vtemian" class="col-span-8">vtemian</a>
             </div>        
             <div class="grid grid-cols-12 gap-2">
-                <span class="text-muted col-span-4">X</span>
+                <span class="col-span-4 text-muted">X</span>
                 <a href="https://x.com/vtemian" class="col-span-8">@vtemian</a>
             </div>
         </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,10 +1,10 @@
 {{ define "content" }}
-<div class="max-w-2xl mx-auto py-12 px-5 flex flex-col gap-12">
-    <a href="/" class="font-mono text-xs text-muted tracking-wide">Back to home</a>
+<div class="mx-auto flex max-w-2xl flex-col gap-12 px-5 py-12">
+    <a href="/" class="font-mono text-xs tracking-wide text-muted">Back</a>
     <article class="flex flex-col gap-12">
-        <header>
+        <header class="flex flex-col gap-2">
             <h1 class="text-2xl">{{ .Title }}</h1>
-            <p class="text-link text-xs">{{ .Date.Format "January 2006" }}</p>
+            <p class="text-xs text-link">{{ .Date.Format "January 2006" }}</p>
         </header>
         <div class="flex flex-col gap-4">
             {{ .Content }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.css">
 
 <link rel="stylesheet"
-      href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/tokyo-night-dark.min.css">
+      href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/nord.min.css">
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>
 

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -1,0 +1,39 @@
+<button id="theme-toggle" aria-label="Toggle dark mode" class="relative flex h-8 w-8 cursor-pointer items-center justify-center text-muted transition-colors duration-200 hover:text-ink">
+    <svg id="icon-sun" class="absolute h-5 w-5 transition-all duration-300 ease-out" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5"/>
+        <line x1="12" y1="1" x2="12" y2="3"/>
+        <line x1="12" y1="21" x2="12" y2="23"/>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+        <line x1="1" y1="12" x2="3" y2="12"/>
+        <line x1="21" y1="12" x2="23" y2="12"/>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+    </svg>
+    <svg id="icon-moon" class="absolute h-5 w-5 transition-all duration-300 ease-out" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+</button>
+
+<script>
+(() => {
+    const toggle = document.getElementById('theme-toggle');
+    const sun = document.getElementById('icon-sun');
+    const moon = document.getElementById('icon-moon');
+
+    const update = (dark) => {
+        sun.style.opacity = dark ? '1' : '0';
+        sun.style.transform = dark ? 'rotate(0deg)' : 'rotate(-90deg)';
+        moon.style.opacity = dark ? '0' : '1';
+        moon.style.transform = dark ? 'rotate(90deg)' : 'rotate(0deg)';
+    };
+
+    update(document.documentElement.classList.contains('dark'));
+
+    toggle.addEventListener('click', () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.setItem('theme', dark ? 'dark' : 'light');
+        update(dark);
+    });
+})();
+</script>


### PR DESCRIPTION
## Summary
- Sun/moon SVG toggle in avatar section with rotation + opacity animation
- FOUC-prevention inline script reads localStorage before paint
- Dark CSS variable overrides for all theme tokens
- Reordered Tailwind classes to canonical order across all templates
- Hover transition on writing list articles

## Dark palette
| Token | Light | Dark |
|-------|-------|------|
| ink | #2c3b49 | #EFEFEF |
| muted | #60646F | #bec8de |
| border | #E8E8EC | #2e3038 |
| bg | #fcfcfc | #151618 |

## Test plan
- [x] Click toggle on homepage, all sections adapt colors
- [x] Navigate to article, dark mode persists
- [x] Refresh page, no FOUC, theme persists from localStorage
- [x] Code blocks, tables, inline code readable in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)